### PR TITLE
Fix month validation in calculators

### DIFF
--- a/calcPrimeiraInsc.js
+++ b/calcPrimeiraInsc.js
@@ -46,17 +46,24 @@ calcularButton.addEventListener("click", function () {
     return;
   }
 
-  if (meses.includes(mesSelecionado)) {
+  if (mesSelecionado === "Selecione o Mês") {
+    resultadoElement.textContent = "Escolha o mês desejado.";
+    return;
+  } else if (meses.includes(mesSelecionado)) {
     var mesesCalculados =
       (valorAnuidadePrimeiraInscricao / 12) * (12 - mesesMap[mesSelecionado] + 1);
     var inscricao = Math.ceil(mesesCalculados * 100) / 100 + taxaInscricao;
 
-    resultadoElement.textContent = "A primeira inscrição de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " é de R$" + inscricao.toFixed(2);
-  } else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+    resultadoElement.textContent =
+      "A primeira inscrição de " +
+      categoriaSelect.value +
+      " para o mês de " +
+      mesSelect.value +
+      " é de R$" +
+      inscricao.toFixed(2);
+  } else if (["janeiro", "fevereiro", "março", "abril", "maio"].includes(mesSelecionado.toLowerCase())) {
     var valorUnico = parseFloat(valorAnuidadePrimeiraInscricao) + parseFloat(taxaInscricao);
-    resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-  } if (mesSelecionado === "Selecione o Mês") {
-  resultadoElement.textContent = "Escolha o mês desejado.";
-  return;
-}
+    resultadoElement.textContent =
+      "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
+  }
 });

--- a/calcReabertura.js
+++ b/calcReabertura.js
@@ -46,17 +46,24 @@ if (categoriaReabertura === "Auxiliar") {
   return;
 }
 
-if (meses.includes(mesSelecionado)) {
+if (mesSelecionado === "Selecione o Mês") {
+  resultadoElement.textContent = "Escolha o mês desejado.";
+  return;
+} else if (meses.includes(mesSelecionado)) {
   var mesesCalculados =
     (valorAnuidadeReabertura / 12) * (12 - mesesMap[mesSelecionado] + 1);
   var reabertura = Math.ceil(mesesCalculados * 100) / 100 + taxaReab;
 
-  resultadoElement.textContent = "A reabertura de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " está no valor de R$" + reabertura.toFixed(2);
-} else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+  resultadoElement.textContent =
+    "A reabertura de " +
+    categoriaSelect.value +
+    " para o mês de " +
+    mesSelect.value +
+    " está no valor de R$" +
+    reabertura.toFixed(2);
+} else if (["janeiro", "fevereiro", "março", "abril", "maio"].includes(mesSelecionado.toLowerCase())) {
   var valorUnico = parseFloat(valorAnuidadeReabertura) + parseFloat(taxaReab);
-  resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-} if (mesSelecionado === "Selecione o Mês") {
-resultadoElement.textContent = "Escolha o mês desejado.";
-return;
+  resultadoElement.textContent =
+    "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
 }
 });

--- a/calcSecundaria.js
+++ b/calcSecundaria.js
@@ -46,17 +46,24 @@ if (categoriaSec === "Auxiliar") {
   return;
 }
 
-if (meses.includes(mesSelecionado)) {
+if (mesSelecionado === "Selecione o Mês") {
+  resultadoElement.textContent = "Escolha o mês desejado.";
+  return;
+} else if (meses.includes(mesSelecionado)) {
   var mesesCalculados =
     (valorAnuidadeSec / 12) * (12 - mesesMap[mesSelecionado] + 1);
   var secundaria = Math.ceil(mesesCalculados * 100) / 100 + taxaSec;
 
-  resultadoElement.textContent = "A inscrição secundária de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " está no valor de R$" + secundaria.toFixed(2);
-} else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+  resultadoElement.textContent =
+    "A inscrição secundária de " +
+    categoriaSelect.value +
+    " para o mês de " +
+    mesSelect.value +
+    " está no valor de R$" +
+    secundaria.toFixed(2);
+} else if (["janeiro", "fevereiro", "março", "abril", "maio"].includes(mesSelecionado.toLowerCase())) {
   var valorUnico = parseFloat(valorAnuidadeSec) + parseFloat(taxaSec);
-  resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-} if (mesSelecionado === "Selecione o Mês") {
-resultadoElement.textContent = "Escolha o mês desejado.";
-return;
+  resultadoElement.textContent =
+    "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
 }
 });


### PR DESCRIPTION
## Summary
- fix `mesSelecionado` logic in the calculators
- ensure invalid month selection is handled separately

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bc8a21e9883248520eaf853bcba8d