### PR TITLE
Fix conditional for early months

### DIFF
--- a/calcPrimeiraInsc.js
+++ b/calcPrimeiraInsc.js
@@ -52,11 +52,13 @@ calcularButton.addEventListener("click", function () {
     var inscricao = Math.ceil(mesesCalculados * 100) / 100 + taxaInscricao;
 
     resultadoElement.textContent = "A primeira inscrição de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " é de R$" + inscricao.toFixed(2);
-  } else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+  } else if (["janeiro","fevereiro","março","abril","maio"].includes(mesSelecionado.toLowerCase())) {
     var valorUnico = parseFloat(valorAnuidadePrimeiraInscricao) + parseFloat(taxaInscricao);
     resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-  } if (mesSelecionado === "Selecione o Mês") {
-  resultadoElement.textContent = "Escolha o mês desejado.";
-  return;
-}
+  }
+
+  if (mesSelecionado === "Selecione o Mês") {
+    resultadoElement.textContent = "Escolha o mês desejado.";
+    return;
+  }
 });

--- a/calcReabertura.js
+++ b/calcReabertura.js
@@ -52,11 +52,13 @@ if (meses.includes(mesSelecionado)) {
   var reabertura = Math.ceil(mesesCalculados * 100) / 100 + taxaReab;
 
   resultadoElement.textContent = "A reabertura de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " está no valor de R$" + reabertura.toFixed(2);
-} else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+} else if (["janeiro","fevereiro","março","abril","maio"].includes(mesSelecionado.toLowerCase())) {
   var valorUnico = parseFloat(valorAnuidadeReabertura) + parseFloat(taxaReab);
   resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-} if (mesSelecionado === "Selecione o Mês") {
-resultadoElement.textContent = "Escolha o mês desejado.";
-return;
+}
+
+if (mesSelecionado === "Selecione o Mês") {
+  resultadoElement.textContent = "Escolha o mês desejado.";
+  return;
 }
 });

--- a/calcSecundaria.js
+++ b/calcSecundaria.js
@@ -52,11 +52,13 @@ if (meses.includes(mesSelecionado)) {
   var secundaria = Math.ceil(mesesCalculados * 100) / 100 + taxaSec;
 
   resultadoElement.textContent = "A inscrição secundária de " + categoriaSelect.value + " para o mês de " + mesSelect.value + " está no valor de R$" + secundaria.toFixed(2);
-} else { (["Janeiro", "Fevereiro", "Março", "Abril", "Maio"].includes(mesSelecionado.toLowerCase())) 
+} else if (["janeiro","fevereiro","março","abril","maio"].includes(mesSelecionado.toLowerCase())) {
   var valorUnico = parseFloat(valorAnuidadeSec) + parseFloat(taxaSec);
   resultadoElement.textContent = "Para os meses de Janeiro à Maio, o valor é de R$" + valorUnico;
-} if (mesSelecionado === "Selecione o Mês") {
-resultadoElement.textContent = "Escolha o mês desejado.";
-return;
+}
+
+if (mesSelecionado === "Selecione o Mês") {
+  resultadoElement.textContent = "Escolha o mês desejado.";
+  return;
 }
 });


### PR DESCRIPTION
## Summary
- fix conditional month handling in `calcPrimeiraInsc.js`
- apply the same fix to `calcReabertura.js` and `calcSecundaria.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bc8adfe4c8324b28d622c2bd7e378