### PR TITLE
Clean up iframe navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,16 +10,13 @@
         <tr>
             <td>
                 <div id="info"><h1>Selecione a opção desejada.</h1>
-                <button class="button" onclick="abrirPagina('calcTipoInscricao.html?tipo=primeira')">Primeira Inscrição</button>
-                <button class="button" onclick="abrirPagina('calcTipoInscricao.html?tipo=reabertura')">Reabertura de Inscrição</button>
-                <button class="button" onclick="abrirPagina('calcTipoInscricao.html?tipo=secundaria')">Inscrição Secundária</button>
             </div>
             </td>
         </tr>
         <tr>
             <td>
                 <div id="container">
-                <iframe id="iframe" src="" width="800" height="600"></iframe>
+                <iframe id="iframe" src="calcTipoInscricao.html" width="800" height="600"></iframe>
                 <h1>Informações úteis</h1>
                 <!--
                 <div class="card">
@@ -84,7 +81,6 @@
     document.getElementById("taxa_reab").textContent = valores.taxaReab.toFixed(2);
     document.getElementById("taxa_sec").textContent = valores.taxaSec.toFixed(2);
     </script>
-    <script src="janelas.js" type="text/javascript"></script>
     <a id="myMark" href="" target="_blank">Made by Felipe Nascimento</a>
 </body>
 </html>

--- a/janelas.js
+++ b/janelas.js
@@ -1,3 +1,0 @@
-function abrirPagina(url) {
-    document.getElementById('iframe').src = url;
-}


### PR DESCRIPTION
## Summary
- remove index buttons for navigation
- load `calcTipoInscricao.html` by default in the iframe
- drop unused `janelas.js` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687be8dc9b4483249c6e4e4a82cc46c0