### PR TITLE
Add left sidebar for support materials

### DIFF
--- a/style.css
+++ b/style.css
@@ -208,11 +208,13 @@ display: flex;
 }
 
 #wrapper .container {
-  margin-left: 20px;
+  margin-left: 30px;
 }
 
 #material-apoio {
-  max-width: 200px;
+  width: 100%;
+  max-width: 250px;
+  margin-right: 20px;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- position "Material de Apoio" section on the left side
- leave space for the select box by adding margin
- keep responsive layout stacking the sidebar on small screens

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687eac56e67c8324badd9c8adec5567c