### PR TITLE
Atualiza layout responsivo

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,12 @@
 body{
-	background: white;
-  	color: #666;
- 	font-family: sans-serif;
-	margin: 0;
- 	padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background: white;
+        color: #666;
+        font-family: sans-serif;
+        margin: 0;
+        padding: 0;
 
   /* 
   Desabilitar seleção de texto
@@ -195,6 +198,7 @@ padding: 20px;
   width: 100%;
   justify-content: center;
   align-items: flex-start;
+  gap: 30px;
 }
 
 #wrapper .container {
@@ -206,9 +210,10 @@ padding: 20px;
   width: 100%;
   max-width: 250px;
   margin-right: 20px;
+  text-align: left;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   #wrapper {
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Resumo
- restaura `display: flex` no `<body>` para manter o layout centralizado
- ajusta `#wrapper` com `gap: 30px`
- define `#material-apoio` alinhado à esquerda
- altera breakpoint para `768px` no layout vertical

## Testes
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eb88e59ec8324a64ff536ba1bfa65